### PR TITLE
Add flag to specify paths for protobuf files

### DIFF
--- a/cmd/protoc-gen-twirp-swagger/main.go
+++ b/cmd/protoc-gen-twirp-swagger/main.go
@@ -34,7 +34,7 @@ func main() {
 				continue
 			}
 
-			writer := swagger.NewWriter(in, *hostname, *pathPrefix)
+			writer := swagger.NewWriter(in, *hostname, *pathPrefix, []string{}) // TODO: support --proto_path
 			if err := writer.WalkFile(); err != nil {
 				if errors.Is(err, swagger.ErrNoServiceDefinition) {
 					log.Debugf("skip writing file, %s: %q", err, in)

--- a/cmd/twirp-swagger-gen/main.go
+++ b/cmd/twirp-swagger-gen/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"strings"
 
 	"github.com/apex/log"
 	"github.com/davecgh/go-spew/spew"
@@ -11,12 +12,12 @@ import (
 
 var _ = spew.Dump
 
-func parse(hostname, filename, output, prefix string) error {
+func parse(hostname, filename, output, prefix, protoPath string) error {
 	if filename == output {
 		return errors.New("output file must be different than input file")
 	}
 
-	writer := swagger.NewWriter(filename, hostname, prefix)
+	writer := swagger.NewWriter(filename, hostname, prefix, strings.Split(protoPath, ","))
 	if err := writer.WalkFile(); err != nil {
 		if !errors.Is(err, swagger.ErrNoServiceDefinition) {
 			return err
@@ -31,11 +32,13 @@ func main() {
 		out        string
 		host       string
 		pathPrefix string
+		protoPath  string
 	)
 	flag.StringVar(&in, "in", "", "Input source .proto file")
 	flag.StringVar(&out, "out", "", "Output swagger.json file")
 	flag.StringVar(&host, "host", "api.example.com", "API host name")
-	flag.StringVar(&pathPrefix, "pathPrefix", "/twirp", "Twrirp server path prefix")
+	flag.StringVar(&pathPrefix, "pathPrefix", "/twirp", "Twirp server path prefix")
+	flag.StringVar(&protoPath, "protoPath", "", "Path to .proto files (comma-separated))")
 	flag.Parse()
 
 	if in == "" {
@@ -48,7 +51,7 @@ func main() {
 		log.Fatalf("Missing parameter: -host [api.example.com]")
 	}
 
-	if err := parse(host, in, out, pathPrefix); err != nil {
+	if err := parse(host, in, out, pathPrefix, protoPath); err != nil {
 		log.WithError(err).Fatal("exit with error")
 	}
 }


### PR DESCRIPTION
This adds support for specifying import paths for proto files.

Flag `-protoPath` added to `twirp-swagger-gen`, accepts comma-separated list of directories to search for proto files when importing.

I did not modify `protoc-gen-twirp-swagger` in the same way, but it should use the `--proto_path` argument from `protoc`. I didn't take the time to understand how to wire that argument, as I've been using `twirp-swagger-gen` instead.