### PR TITLE
Add flag for enabling camelCase field names

### DIFF
--- a/cmd/protoc-gen-twirp-swagger/main.go
+++ b/cmd/protoc-gen-twirp-swagger/main.go
@@ -21,6 +21,7 @@ func main() {
 	hostname := flags.String("hostname", "example.com", "")
 	pathPrefix := flags.String("path_prefix", "/twirp", "")
 	outputSuffix := flags.String("output_suffix", ".swagger.json", "")
+	camelCase := flags.Bool("camel_case", false, "")
 	opts := protogen.Options{
 		ParamFunc: flags.Set,
 	}
@@ -34,7 +35,7 @@ func main() {
 				continue
 			}
 
-			writer := swagger.NewWriter(in, *hostname, *pathPrefix)
+			writer := swagger.NewWriter(in, *hostname, *pathPrefix, *camelCase)
 			if err := writer.WalkFile(); err != nil {
 				if errors.Is(err, swagger.ErrNoServiceDefinition) {
 					log.Debugf("skip writing file, %s: %q", err, in)

--- a/cmd/twirp-swagger-gen/main.go
+++ b/cmd/twirp-swagger-gen/main.go
@@ -11,12 +11,12 @@ import (
 
 var _ = spew.Dump
 
-func parse(hostname, filename, output, prefix string) error {
+func parse(hostname, filename, output, prefix string, camelCase bool) error {
 	if filename == output {
 		return errors.New("output file must be different than input file")
 	}
 
-	writer := swagger.NewWriter(filename, hostname, prefix)
+	writer := swagger.NewWriter(filename, hostname, prefix, camelCase)
 	if err := writer.WalkFile(); err != nil {
 		if !errors.Is(err, swagger.ErrNoServiceDefinition) {
 			return err
@@ -31,11 +31,13 @@ func main() {
 		out        string
 		host       string
 		pathPrefix string
+		camelCase  bool
 	)
 	flag.StringVar(&in, "in", "", "Input source .proto file")
 	flag.StringVar(&out, "out", "", "Output swagger.json file")
 	flag.StringVar(&host, "host", "api.example.com", "API host name")
-	flag.StringVar(&pathPrefix, "pathPrefix", "/twirp", "Twrirp server path prefix")
+	flag.StringVar(&pathPrefix, "pathPrefix", "/twirp", "Twirp server path prefix")
+	flag.BoolVar(&camelCase, "camelCase", false, "Use camelCase for field names")
 	flag.Parse()
 
 	if in == "" {
@@ -48,7 +50,7 @@ func main() {
 		log.Fatalf("Missing parameter: -host [api.example.com]")
 	}
 
-	if err := parse(host, in, out, pathPrefix); err != nil {
+	if err := parse(host, in, out, pathPrefix, camelCase); err != nil {
 		log.WithError(err).Fatal("exit with error")
 	}
 }


### PR DESCRIPTION
This adds support for `protojson`-style field names (camelCase), consistent with using [twirp.WithServerJSONCamelCaseNames](https://pkg.go.dev/github.com/twitchtv/twirp#WithServerJSONCamelCaseNames). It is enabled with a flag, disabled by default.